### PR TITLE
change(publish): Adds a publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "description": "Addepar sass-lint configuration",
   "main": "index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "@addepar:registry": "https://registry.npmjs.org/"
+  }
 }


### PR DESCRIPTION
@Addepar/ice 

This PR adds a publishConfig to package.json, allowing us to override the registry to point on the public NPM registry rather than our private one. I think this should be the way we mark packages as public in general - by default we publish to the private repo and opt into public packages.