### PR TITLE
reassign errors and warnings, add some new rules

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,11 +23,11 @@ rules:
   no-color-keywords: 2
   no-color-literals: 2
   no-debug: 2
-  no-duplicate-properties: 1
+  no-duplicate-properties: 2
   no-empty-rulesets: 2
   no-ids: 2
   no-invalid-hex: 2
-  no-misspelled-properties: 1
+  no-misspelled-properties: 2
   no-mergeable-selectors: 2
   no-trailing-whitespace: 2
   no-trailing-zero: 2

--- a/config.yml
+++ b/config.yml
@@ -21,32 +21,22 @@ rules:
 
   # Disallows
   no-color-keywords: 2
+  no-color-literals: 2
   no-debug: 2
-  no-duplicate-properties:
-    - 2
-    -
-      exclude:
-        # To allow for fallbacks
-        # TODO(Maddie): eventually get rid of these
-        - background
-        - border
+  no-duplicate-properties: 1
   no-empty-rulesets: 2
   no-ids: 2
   no-invalid-hex: 2
-  no-misspelled-properties:
-    - 2
-    -
-      'extra-properties':
-        - 'border-'
-        - 'margin-'
-        - 'osx-font-smoothing'
-  no-mergeable-selectors: 1
+  no-misspelled-properties: 1
+  no-mergeable-selectors: 2
   no-trailing-whitespace: 2
-  no-url-protocols: 2
+  no-trailing-zero: 2
+  no-url-domains: 2
   no-warn: 2
 
   # Nesting
-  nesting-depth: 1
+  nesting-depth: 2
+  declarations-before-nesting: 2
 
   # Name Formats
   class-name-format:
@@ -70,38 +60,42 @@ rules:
       allow-leading-underscore: false
 
   # Style Guide
+  attribute-quotes: 2
   border-zero:
-    - 1
+    - 2
     -
       convention: 'none'
-  brace-style: 1
-  clean-import-paths: 1
+  brace-style: 2
+  clean-import-paths: 2
   empty-args:
-    - 1
+    - 2
     -
       include: true
   hex-length:
-    - 1
+    - 2
     -
       style: long
-  hex-notation: 1
+  hex-notation: 2
   indentation: 2
   leading-zero:
-    - 1
+    - 2
     -
       include: true
-  quotes: 1
-  shorthand-values: 1
-  url-quotes: 1
-  zero-unit: 1
+  pseudo-element: 2
+  quotes: 2
+  shorthand-values: 2
+  url-quotes: 2
+  zero-unit: 2
 
   # Inner Spacing
-  space-after-colon: 1
-  space-after-comma: 1
-  space-around-operator: 1
-  space-before-bang: 1
-  space-before-brace: 1
+  space-after-bang: 2
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-bang: 2
+  space-before-brace: 2
+  space-before-colon: 2
 
   # Final Items
-  trailing-semicolon: 1
-  final-newline: 1
+  trailing-semicolon: 2
+  final-newline: 2


### PR DESCRIPTION
Decided to do a big update since this hasn't been touched in awhile.

Made most rules give errors instead of warnings. This doc explains my reasoning: https://addepar.atlassian.net/wiki/spaces/EN/pages/181010793/Sass+Lint+Rules#SassLintRules-TheRules

I also found some more rules that made sense to add. Also got rid of old unneeded exceptions.
I have already tested all of this in Iverson and have a branch fixing everything. Most of these only had a few things to fix.

If there are any questions about the use of any rule, the confluence doc explains every single one of them. Opening to changing things if needed of course.

@Addepar/ice 