### PR TITLE
Removing no-color-keywords rule to allow SASS helpers

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,7 +20,7 @@ rules:
   single-line-per-selector: 2
 
   # Disallows
-  no-color-keywords: 2
+  no-color-keywords: 0
   no-color-literals: 2
   no-debug: 2
   no-duplicate-properties: 2


### PR DESCRIPTION
This PR changes the no-color-keywords lint rule to allow usage of SASS helpers like color(neutral, 1000). Another possible option could be to whitelist certain keywords, but I haven't come across a way to do that.

Examples:
https://github.com/Addepar/Iverson/pull/8875#discussion_r282900822
https://github.com/Addepar/Iverson/pull/8883/files#diff-cec58187747e96a1124a6cd4212719f3R53