### PR TITLE
Drop both color keywords and literals from the disallows

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,8 +20,6 @@ rules:
   single-line-per-selector: 2
 
   # Disallows
-  no-color-keywords: 0
-  no-color-literals: 2
   no-debug: 2
   no-duplicate-properties: 2
   no-empty-rulesets: 2


### PR DESCRIPTION
@twokul @chinwei I think this does what you intended in https://github.com/Addepar/sass-lint-config/pull/4. The iteration from that PR a) left the item in the disallow list even though it was allowed and b) didn't actually permit the syntax we want to use downstream.

This should, I've tested it with `yarn link`.