### PR TITLE
Use BEM as class name format

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -54,12 +54,7 @@ rules:
   class-name-format:
     - 2
     -
-      allow-leading-underscore: false
-      ignore:
-        # These are being ignored because the DOM elements are pulled in via
-        # CKEditor and we cannot control the class names
-        - 'cke_tabulation'
-        - 'cke_editable'
+      convention: strictbem
   function-name-format: 2
   mixin-name-format: 2
   placeholder-name-format:


### PR DESCRIPTION
BEM is a highly useful, powerful, and simple naming convention that makes your front-end code easier to read and understand, easier to work with, easier to scale, more robust and explicit, and a lot more strict.
http://getbem.com/